### PR TITLE
Apply pixelRatio scaling

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -802,7 +802,7 @@ DrawStringCmd::DrawStringCmd(float X, float Y, int Align, int Size, int Font, co
             break;
         case 0:
         default:
-            fontName = "Bitstream Vera Mono";
+            fontName = "Bitstream Vera Sans Mono";
             break;
         }
         QFont font(fontName);
@@ -901,7 +901,7 @@ static int l_DrawStringWidth(lua_State* L)
         fontName = "Liberation Sans Bold";
         fontKey = "2";
     } else {
-        fontName = "Bitstream Vera Mono";
+        fontName = "Bitstream Vera Sans Mono";
     }
     QString text(lua_tostring(L, 3));
 
@@ -937,7 +937,7 @@ static int l_DrawStringCursorIndex(lua_State* L)
     } else if (fontName == "VAR BOLD") {
         fontName = "Liberation Sans Bold";
     } else {
-        fontName = "Bitstream Vera Mono";
+        fontName = "Bitstream Vera Sans Mono";
     }
     QString text(lua_tostring(L, 3));
 

--- a/pobwindow.hpp
+++ b/pobwindow.hpp
@@ -5,6 +5,7 @@
 #include <QPainter>
 #include <QTimer>
 #include <memory>
+#include <QScreen>
 
 #include "main.h"
 #include "subscript.hpp"
@@ -61,6 +62,8 @@ public:
     void wheelEvent(QWheelEvent *event);
     void keyPressEvent(QKeyEvent *event);
     void keyReleaseEvent(QKeyEvent *event);
+    int scaleWidth;
+    int scaleHeight;
 
     void LAssert(lua_State* L, int cond, const char* fmt, ...);
     int IsUserData(lua_State* L, int index, const char* metaName);


### PR DESCRIPTION
I created a fork to try things working with the new PoB file structure.  In that regard, I ended up [forking](https://github.com/jhofmeyr/PoBMacOSBuild) [PoBMacOSBuild](https://github.com/ManWithBear/PoBMacOSBuild) because it automates the process a bit.  The recent changes to the Community PoB file structure meant a few extra steps to get everything in the right place.

Once the front-end was loading, the scaling was off.  I managed to find some info on using `devicePixelRatio` to rescale output for retina displays.  This seems to work well for me locally, although the font size seems a little off in some areas.

I don't know any of the underlying tech (QT / OpenGL / c or lua), so I'm sure this can be greatly improved 🙏 
